### PR TITLE
Release v0.1.5

### DIFF
--- a/bitsec/utils/data.py
+++ b/bitsec/utils/data.py
@@ -147,7 +147,7 @@ Modified code:"""
         # Use the LLM to inject the vulnerability
         response = chat_completion(
             prompt,
-            max_tokens=30000,
+            max_tokens=16000,
             temperature=0.9,
             response_format=NewlyVulnerableCode
         )

--- a/bitsec/utils/data.py
+++ b/bitsec/utils/data.py
@@ -147,8 +147,8 @@ Modified code:"""
         # Use the LLM to inject the vulnerability
         response = chat_completion(
             prompt,
-            max_tokens=10000,
-            temperature=1.0,
+            max_tokens=30000,
+            temperature=0.9,
             response_format=NewlyVulnerableCode
         )
         

--- a/bitsec/validator/forward.py
+++ b/bitsec/validator/forward.py
@@ -62,11 +62,21 @@ async def forward(self):
     if len(miner_uids) == 0:
         bt.logging.warning(f"❌❌❌❌❌ No miners found, skipping challenge")
         return
-
+    
+    # generate challenge
+    # handle errors when generating challenges
     vulnerable = random.random() < 0.8
-    challenge, expected_response = create_challenge(vulnerable=vulnerable)
-    bt.logging.info(f"created challenge")
-    wandb.log({"challenge": challenge})
+    challenge = None
+    expected_response = None
+
+    while not challenge:
+        try:
+            challenge, expected_response = create_challenge(vulnerable=vulnerable)
+            bt.logging.info(f"created challenge")
+            wandb.log({"challenge": challenge})
+        except Exception as e:
+            bt.logging.warning(f"Error creating challenge: {e}")
+            time.sleep(1)
 
 
     # The dendrite client queries the network.


### PR DESCRIPTION
This pull request includes a change to the `bitsec/utils/data.py` file to adjust the maximum token limit for the chat completion response.

* [`bitsec/utils/data.py`](diffhunk://#diff-91d02a647c0317bdd57864c64c3d281bc825a6442140135ba7f174f604b01bddL150-R150): Reduced the `max_tokens` parameter from 30000 to 16000 in the `chat_completion` function call within the `NewlyVulnerableCode` class.