### PR TITLE
Bumped bittensor version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==9.4.0
+bittensor==9.9.0
 dotenv==0.9.9
 flaky>=3.8.1
 numpy>=1


### PR DESCRIPTION
Bumped bittensor version to 9.9.0 which was required to handle enforced commit reveal